### PR TITLE
Update wikimedia address

### DIFF
--- a/geolocator.js
+++ b/geolocator.js
@@ -78,7 +78,7 @@
       // Google Maps version to be loaded
       mapsVersion = '3.23',
       // wikimedia provides location-by-IP information.
-      ipGeoSource = '//geoiplookup.wikimedia.org/',
+      ipGeoSource = '//bits.wikimedia.org/geoiplookup',
       // The index of the current IP source service.
       sourceIndex;
 
@@ -324,4 +324,3 @@
     root.geolocator = geolocator;
   }
 }.call(this));
-


### PR DESCRIPTION
Address has moved (see https://github.com/onury/geolocator/issues/32). Currently causing error:
<img width="502" alt="screen shot 2016-10-31 at 14 28 18" src="https://cloud.githubusercontent.com/assets/867840/19847017/5088d6fc-9f76-11e6-91b6-e2ec0cf4b6cb.png">
